### PR TITLE
starts #42; call timespan click from drillDown

### DIFF
--- a/src/directives/mwlCalendarMonth.js
+++ b/src/directives/mwlCalendarMonth.js
@@ -62,7 +62,10 @@ angular
         };
 
         $scope.drillDown = function(day) {
-          $scope.calendarCtrl.changeView('day', moment($scope.currentDay).clone().date(day).toDate());
+          var date = moment($scope.currentDay).clone().date(day).toDate();
+          if ($scope.timespanClick({calendarDate: date}) !== false) {
+            $scope.calendarCtrl.changeView('day', date);
+          }
         };
 
         $scope.highlightEvent = function(event, shouldAddClass) {

--- a/src/directives/mwlCalendarWeek.js
+++ b/src/directives/mwlCalendarWeek.js
@@ -12,7 +12,8 @@ angular
         events: '=calendarEvents',
         currentDay: '=calendarCurrentDay',
         eventClick: '=calendarEventClick',
-        useIsoWeek: '=calendarUseIsoWeek'
+        useIsoWeek: '=calendarUseIsoWeek',
+        timespanClick: '=calendarTimespanClick'
       },
       controller: function($scope, moment, calendarHelper) {
         function updateView() {
@@ -20,7 +21,10 @@ angular
         }
 
         $scope.drillDown = function(day) {
-          $scope.calendarCtrl.changeView('day', moment($scope.currentDay).clone().date(day).toDate());
+          var date = moment($scope.currentDay).clone().date(day).toDate();
+          if ($scope.timespanClick({calendarDate: date}) !== false) {
+            $scope.calendarCtrl.changeView('day', date);
+          }
         };
 
         $scope.$watch('currentDay', updateView);

--- a/src/directives/mwlCalendarYear.js
+++ b/src/directives/mwlCalendarYear.js
@@ -58,7 +58,10 @@ angular
         };
 
         $scope.drillDown = function(month) {
-          $scope.calendarCtrl.changeView('month', moment($scope.currentDay).clone().month(month).toDate());
+          var date = moment($scope.currentDay).clone().month(month).toDate();
+          if ($scope.timespanClick({calendarDate: date}) !== false) {
+            $scope.calendarCtrl.changeView('month', date);
+          }
         };
       },
       link: function(scope, element, attrs, calendarCtrl) {

--- a/templates/main.html
+++ b/templates/main.html
@@ -34,6 +34,7 @@
     calendar-current-day="currentDay"
     calendar-event-click="eventClick"
     calendar-use-iso-week="useIsoWeek"
+    calendar-timespan-click="timespanClick"
     ng-switch-when="week"
     ></mwl-calendar-week>
 


### PR DESCRIPTION
for #42 

The drillDown function on year, month, and week view will call timespanClick and if that function returns false, it will not change the view. This allows the user to disable the drillDown depending on the date or whatever else.