### PR TITLE
Update mwlCalendarHourList.js

### DIFF
--- a/src/directives/mwlCalendarHourList.js
+++ b/src/directives/mwlCalendarHourList.js
@@ -84,6 +84,10 @@ angular
     };
 
     vm.getClickedDate = function(baseDate, minutes, days) {
+      var date = new Date(baseDate);
+      if(date.getMinutes()!==minutes){
+        minutes = date.getMinutes();
+      }
       return moment(baseDate).clone().startOf('hour').add(minutes, 'minutes').add(days || 0, 'days').toDate();
     };
 


### PR DESCRIPTION
When the start time of the day view of a calendar does not start at an hour with 0 minutes (i.e. day-view-start="09:15") the calendarDate object passed on the on-timespan-click event for the first hour span has the wrong times. For example in the time span of the first hour (9:15 - 10:00, assuming you are day-view-split="15") you'll get calendarDate objects 9:00, 9:15, 9:30. The correct calendarDate objects should be 9:15, 9:30, 9:45