### PR TITLE
feat(excluded-days): Allow users to specify a set of days to be excluded from month and week view

### DIFF
--- a/docs/examples/examples.json
+++ b/docs/examples/examples.json
@@ -38,6 +38,9 @@
   "key": "day-view-start-end",
   "label": "Day view start / end time"
 }, {
+  "key": "exclude-weekdays",
+  "label": "Exclude days"
+}, {
   "key": "day-view-split",
   "label": "Day view minute split"
 }, {

--- a/docs/examples/exclude-weekdays/javascript.js
+++ b/docs/examples/exclude-weekdays/javascript.js
@@ -1,0 +1,28 @@
+angular
+  .module('mwl.calendar.docs')
+  .controller('ExcludeWeekdays', function(moment, calendarConfig) {
+
+    var vm = this;
+    vm.events = [
+      {
+        title: 'An event',
+        color: calendarConfig.colorTypes.warning,
+        startsAt: moment().startOf('week').subtract(2, 'days').add(8, 'hours').toDate(),
+        endsAt: moment().startOf('week').add(1, 'week').add(9, 'hours').toDate()
+      }, {
+        title: '<i class="glyphicon glyphicon-asterisk"></i> <span class="text-primary">Another event</span>, with a <i>html</i> title',
+        color: calendarConfig.colorTypes.info,
+        startsAt: moment().subtract(1, 'day').toDate(),
+        endsAt: moment().add(5, 'days').toDate()
+      }, {
+        title: 'This is a really long event title that occurs on every year',
+        color: calendarConfig.colorTypes.important,
+        startsAt: moment().startOf('day').add(7, 'hours').toDate(),
+        endsAt: moment().startOf('day').add(19, 'hours').toDate()
+      }
+    ];
+    vm.calendarView = 'week';
+    vm.viewDate = new Date();
+    vm.excludedDays = [0, 6];
+
+  });

--- a/docs/examples/exclude-weekdays/markup.html
+++ b/docs/examples/exclude-weekdays/markup.html
@@ -1,0 +1,9 @@
+<div ng-controller="ExcludeWeekdays as vm">
+  <ng-include src="'calendarControls.html'"></ng-include>
+  <mwl-calendar
+    events="vm.events"
+    view="vm.calendarView"
+    view-date="vm.viewDate"
+    excluded-days="vm.excludedDays">
+  </mwl-calendar>
+</div>

--- a/docs/examples/exclude-weekdays/markup.html
+++ b/docs/examples/exclude-weekdays/markup.html
@@ -1,5 +1,5 @@
 <div ng-controller="ExcludeWeekdays as vm">
-  <h3 ng-if="vm.calendarView == 'day'">{{vm.viewDate | date}}</h3>
+  <h2 class="text-center">{{ vm.calendarTitle }}</h2>
 
   <div class="row">
     <div class="col-md-6 text-center">
@@ -44,12 +44,13 @@
       </div>
     </div>
   </div>
-   
+
   <br>
 
   <mwl-calendar
     events="vm.events"
     view="vm.calendarView"
+    view-title="vm.calendarTitle"
     view-date="vm.viewDate"
     excluded-days="vm.excludedDays">
   </mwl-calendar>

--- a/docs/examples/exclude-weekdays/markup.html
+++ b/docs/examples/exclude-weekdays/markup.html
@@ -1,5 +1,52 @@
 <div ng-controller="ExcludeWeekdays as vm">
-  <ng-include src="'calendarControls.html'"></ng-include>
+  <h3 ng-if="vm.calendarView == 'day'">{{vm.viewDate | date}}</h3>
+
+  <div class="row">
+    <div class="col-md-6 text-center">
+      <div class="btn-group">
+
+        <button
+          class="btn btn-primary"
+          mwl-date-modifier
+          date="vm.viewDate"
+          decrement="vm.calendarView"
+          ng-click="vm.cellIsOpen = false"
+          excluded-days="vm.excludedDays">
+          Previous
+        </button>
+        <button
+          class="btn btn-default"
+          mwl-date-modifier
+          date="vm.viewDate"
+          set-to-today
+          ng-click="vm.cellIsOpen = false">
+          Today
+        </button>
+        <button
+          class="btn btn-primary"
+          mwl-date-modifier
+          date="vm.viewDate"
+          increment="vm.calendarView"
+          ng-click="vm.cellIsOpen = false"
+          excluded-days="vm.excludedDays">
+          Next
+        </button>
+      </div>
+    </div>
+
+    <br class="visible-xs visible-sm">
+
+    <div class="col-md-6 text-center">
+      <div class="btn-group">
+        <label class="btn btn-primary" ng-model="vm.calendarView" uib-btn-radio="'month'" ng-click="vm.cellIsOpen = false">Month</label>
+        <label class="btn btn-primary" ng-model="vm.calendarView" uib-btn-radio="'week'" ng-click="vm.cellIsOpen = false">Week</label>
+        <label class="btn btn-primary" ng-model="vm.calendarView" uib-btn-radio="'day'" ng-click="vm.cellIsOpen = false">Day</label>
+      </div>
+    </div>
+  </div>
+   
+  <br>
+
   <mwl-calendar
     events="vm.events"
     view="vm.calendarView"

--- a/src/directives/mwlCalendar.js
+++ b/src/directives/mwlCalendar.js
@@ -38,6 +38,7 @@ angular
       }
 
       vm.events = vm.events || [];
+      vm.excludedDays = vm.excludedDays || [];
 
       var previousDate = moment(vm.viewDate);
       var previousView = vm.view;
@@ -137,6 +138,7 @@ angular
         viewDate: '=',
         cellIsOpen: '=?',
         cellAutoOpenDisabled: '=?',
+        excludedDays: '=?',
         slideBoxDisabled: '=?',
         customTemplateUrls: '=?',
         draggableAutoScroll: '=?',

--- a/src/directives/mwlCalendarMonth.js
+++ b/src/directives/mwlCalendarMonth.js
@@ -15,7 +15,7 @@ angular
       vm.openRowIndex = null;
       vm.openDayIndex = null;
 
-      if (vm.cellIsOpen && vm.view) {
+      if (vm.cellIsOpen && vm.view && vm.weekDays) {
         vm.view.forEach(function(day, dayIndex) {
           if (moment(vm.viewDate).startOf('day').isSame(day.date)) {
             vm.openDayIndex = dayIndex;

--- a/src/directives/mwlCalendarMonth.js
+++ b/src/directives/mwlCalendarMonth.js
@@ -27,9 +27,9 @@ angular
 
     $scope.$on('calendar.refreshView', function() {
 
-      vm.weekDays = calendarHelper.getWeekDayNames();
+      vm.weekDays = calendarHelper.getWeekDayNames(vm.excludedDays);
 
-      var monthView = calendarHelper.getMonthView(vm.events, vm.viewDate, vm.cellModifier);
+      var monthView = calendarHelper.getMonthView(vm.events, vm.viewDate, vm.cellModifier, vm.excludedDays);
       vm.view = monthView.days;
       vm.monthOffsets = monthView.rowOffsets;
 
@@ -170,6 +170,7 @@ angular
       scope: {
         events: '=',
         viewDate: '=',
+        excludedDays: '=',
         onEventClick: '=',
         onEventTimesChanged: '=',
         onDateRangeSelect: '=',

--- a/src/directives/mwlCalendarMonth.js
+++ b/src/directives/mwlCalendarMonth.js
@@ -19,7 +19,7 @@ angular
         vm.view.forEach(function(day, dayIndex) {
           if (moment(vm.viewDate).startOf('day').isSame(day.date)) {
             vm.openDayIndex = dayIndex;
-            vm.openRowIndex = Math.floor(dayIndex / 7);
+            vm.openRowIndex = Math.floor(dayIndex / vm.weekDays.length);
           }
         });
       }
@@ -68,7 +68,7 @@ angular
           vm.cellIsOpen = false;
         } else {
           vm.openDayIndex = dayIndex;
-          vm.openRowIndex = Math.floor(dayIndex / 7);
+          vm.openRowIndex = Math.floor(dayIndex / vm.weekDays.length);
           vm.cellIsOpen = true;
         }
       }

--- a/src/directives/mwlCalendarWeek.js
+++ b/src/directives/mwlCalendarWeek.js
@@ -27,7 +27,7 @@ angular
           vm.dayViewSplit
         );
       } else {
-        vm.view = calendarHelper.getWeekView(vm.events, vm.viewDate);
+        vm.view = calendarHelper.getWeekView(vm.events, vm.viewDate, vm.excludedDays);
       }
     });
 
@@ -89,6 +89,7 @@ angular
       scope: {
         events: '=',
         viewDate: '=',
+        excludedDays: '=',
         onEventClick: '=',
         onEventTimesChanged: '=',
         dayViewStart: '=',

--- a/src/directives/mwlDateModifier.js
+++ b/src/directives/mwlDateModifier.js
@@ -13,7 +13,7 @@ angular
         vm.date = new Date();
       } else if (angular.isDefined($attrs.increment)) {
         vm.date = moment(vm.date).add(1, vm.increment);
-        if (vm.excludedDays && vm.increment === 'day') {
+        if (vm.excludedDays && vm.increment.indexOf('day') > -1) {
           while (vm.excludedDays.indexOf(vm.date.day()) > -1) {
             vm.date.add(1, vm.increment);
           }
@@ -21,7 +21,7 @@ angular
         vm.date = vm.date.toDate();
       } else if (angular.isDefined($attrs.decrement)) {
         vm.date = moment(vm.date).subtract(1, vm.decrement);
-        if (vm.excludedDays && vm.decrement === 'day') {
+        if (vm.excludedDays && vm.decrement.indexOf('day') > -1) {
           while (vm.excludedDays.indexOf(vm.date.day()) > -1) {
             vm.date.subtract(1, vm.decrement);
           }

--- a/src/directives/mwlDateModifier.js
+++ b/src/directives/mwlDateModifier.js
@@ -12,9 +12,21 @@ angular
       if (angular.isDefined($attrs.setToToday)) {
         vm.date = new Date();
       } else if (angular.isDefined($attrs.increment)) {
-        vm.date = moment(vm.date).add(1, vm.increment).toDate();
+        vm.date = moment(vm.date).add(1, vm.increment);
+        if (vm.excludedDays && vm.increment === 'day') {
+          while (vm.excludedDays.indexOf(vm.date.day()) > -1) {
+            vm.date.add(1, vm.increment);
+          }
+        }
+        vm.date = vm.date.toDate();
       } else if (angular.isDefined($attrs.decrement)) {
-        vm.date = moment(vm.date).subtract(1, vm.decrement).toDate();
+        vm.date = moment(vm.date).subtract(1, vm.decrement);
+        if (vm.excludedDays && vm.decrement === 'day') {
+          while (vm.excludedDays.indexOf(vm.date.day()) > -1) {
+            vm.date.subtract(1, vm.decrement);
+          }
+        }
+        vm.date = vm.date.toDate();
       }
       $scope.$apply();
     }
@@ -34,7 +46,8 @@ angular
       scope: {
         date: '=',
         increment: '=',
-        decrement: '='
+        decrement: '=',
+        excludedDays: '=?'
       },
       bindToController: true
     };

--- a/src/less/calendar.less
+++ b/src/less/calendar.less
@@ -1,7 +1,8 @@
 @import "variables.less";
 @import "grid.less";
+@import "theme.less";
 @import "month.less";
 @import "week.less";
 @import "day.less";
 @import "events.less";
-@import "theme.less";
+

--- a/src/less/grid-mixin.less
+++ b/src/less/grid-mixin.less
@@ -1,0 +1,35 @@
+.gridForWeekOf(@days) {
+  @oneDay: 100% / @days;
+  @oneDayIE: 0.9993781095 * @oneDay;
+  //magic constant, have no idea from where it comes from
+
+  .generate-day();
+
+  .generate-day(@i:1) when (@i =< @days) {
+    .cal-row-fluid .cal-cell@{i} {
+      width:  (@i * @oneDay);
+      *width: (@i * @oneDayIE);
+    }
+
+    .cal-row-fluid .cal-offset@{i},
+    .cal-row-fluid .cal-offset@{i}:first-child,
+    .cal-week-box .cal-offset@{i} {
+      margin-left: (@i * @oneDay);
+      *margin-left: (@i * @oneDayIE);
+    }
+    .generate-day(@i + 1);
+  }
+
+}
+
+.gridForWeeks(@i:1) when (@i =< 7) {
+  .cal-week-box,
+  .cal-month-box
+   {
+    &.cal-grid-@{i} {
+      .gridForWeekOf(@i);
+    }
+  }
+
+  .gridForWeeks(@i + 1);
+}

--- a/src/less/grid.less
+++ b/src/less/grid.less
@@ -1,3 +1,5 @@
+@import "grid-mixin.less";
+
 mwl-calendar {
 
   [class*="cal-cell"] {
@@ -40,82 +42,8 @@ mwl-calendar {
   .cal-row-fluid .controls-row [class*="cal-cell"] + [class*="cal-cell"] {
     margin-left: 0%;
   }
-  .cal-row-fluid .cal-cell7 {
-    width: 100%;
-    *width: 99.94669509594883%;
-  }
-  .cal-row-fluid .cal-cell6 {
-    width: 85.71428571428571%;
-    *width: 85.66098081023453%;
-  }
-  .cal-row-fluid .cal-cell5 {
-    width: 71.42857142857142%;
-    *width: 71.37526652452024%;
-  }
-  .cal-row-fluid .cal-cell4 {
-    width: 57.14285714285714%;
-    *width: 57.089552238805965%;
-  }
-  .cal-row-fluid .cal-cell3 {
-    width: 42.857142857142854%;
-    *width: 42.80383795309168%;
-  }
-  .cal-row-fluid .cal-cell2 {
-    width: 28.57142857142857%;
-    *width: 28.518123667377395%;
-  }
-  .cal-row-fluid .cal-cell1 {
-    width: 14.285714285714285%;
-    *width: 14.232409381663112%;
-  }
-  .cal-week-box .cal-offset7,
-  .cal-row-fluid .cal-offset7,
-  .cal-row-fluid .cal-offset7:first-child {
-    margin-left: 100%;
-    *margin-left: 99.89339019189765%;
-  }
 
-  .cal-week-box .cal-offset6,
-  .cal-row-fluid .cal-offset6,
-  .cal-row-fluid .cal-offset6:first-child {
-    margin-left: 85.71428571428571%;
-    *margin-left: 85.60767590618336%;
-  }
-  .cal-week-box .cal-offset5,
-  .cal-row-fluid .cal-offset5,
-  .cal-row-fluid .cal-offset5:first-child {
-    margin-left: 71.42857142857142%;
-    *margin-left: 71.32196162046907%;
-  }
-  .cal-week-box .cal-offset4,
-  .cal-row-fluid .cal-offset4,
-  .cal-row-fluid .cal-offset4:first-child {
-    margin-left: 57.14285714285714%;
-    *margin-left: 57.03624733475479%;
-  }
-  .cal-week-box .cal-offset3,
-  .cal-row-fluid .cal-offset3,
-  .cal-row-fluid .cal-offset3:first-child {
-    margin-left: 42.857142857142854%;
-    *margin-left: 42.750533049040506%;
-  }
-  .cal-week-box .cal-offset2,
-  .cal-row-fluid .cal-offset2,
-  .cal-row-fluid .cal-offset2:first-child {
-    margin-left: 28.57142857142857%;
-    *margin-left: 28.46481876332622%;
-  }
-  .cal-week-box .cal-offset1,
-  .cal-row-fluid .cal-offset1,
-  .cal-row-fluid .cal-offset1:first-child {
-    margin-left: 14.285714285714285%;
-    *margin-left: 14.17910447761194%;
-  }
-
-  .cal-row-fluid .cal-cell1 {
-    width: 14.285714285714285%;
-    *width: 14.233576642335766%;
-  }
+  .gridForWeeks();
 
   [class*="cal-cell"].hide,
   .cal-row-fluid [class*="cal-cell"].hide {

--- a/src/less/month.less
+++ b/src/less/month.less
@@ -34,18 +34,6 @@ mwl-calendar .cal-month-box {
     cursor: pointer;
   }
 
-  .cal-day-tick {
-    position: absolute;
-    right: 50%;
-    bottom: -21px;
-    padding: 0px 5px;
-    cursor: pointer;
-    z-index: 5;
-    text-align: center;
-    width: 26px;
-    margin-right: -17px;
-  }
-
   .cal-slide-box {
     position: relative;
   }

--- a/src/less/month.less
+++ b/src/less/month.less
@@ -1,25 +1,31 @@
 mwl-calendar .cal-month-box {
-  border-bottom: none;
+  .cal-row-fluid {
+    border-right: @borderSizevert @borderStyle @borderColor;
+    border-left: @borderSizevert @borderStyle @borderColor;
+  }
 
-  .cal-row-head [class*="cal-cell"] {
-    min-height: auto;
-    overflow: hidden;
-    border: 0px solid;
-    text-overflow: ellipsis;
+  .cal-row-head {
+    border-left: none;
+    border-right: none;
+    [class*="cal-cell"] {
+      border: none;
+      overflow: hidden;
+      min-height: unset;
+      text-overflow: ellipsis;
+    }
   }
 
   .cal-month-day {
     position: relative;
     display: block;
     width: 100%;
+    .cal-events-num {
+      margin-left: 10px;
+      margin-top: 18px;
+    }
   }
 
-  .cal-month-day .cal-events-num {
-    margin-left: 10px;
-    margin-top: 18px;
-  }
-
-  #cal-week-box {
+  .cal-week-box-cell {
     position: absolute;
     width: 70px;
     left: -71px;
@@ -38,9 +44,6 @@ mwl-calendar .cal-month-box {
     text-align: center;
     width: 26px;
     margin-right: -17px;
-  }
-  .cal-year-box #cal-day-tick {
-    margin-right: -7px;
   }
 
   .cal-slide-box {

--- a/src/less/month.less
+++ b/src/less/month.less
@@ -1,14 +1,13 @@
-mwl-calendar {
+mwl-calendar .cal-month-box {
+  border-bottom: none;
 
-  .cal-row-head [class*="cal-cell"]:first-child,
   .cal-row-head [class*="cal-cell"] {
     min-height: auto;
     overflow: hidden;
+    border: 0px solid;
     text-overflow: ellipsis;
   }
-  .cal-events-num {
-    margin-top: 20px;
-  }
+
   .cal-month-day {
     position: relative;
     display: block;

--- a/src/less/theme.less
+++ b/src/less/theme.less
@@ -120,6 +120,18 @@ mwl-calendar {
     }
   }
 
+  .cal-day-tick {
+    position: absolute;
+    right: 50%;
+    bottom: -21px;
+    padding: 0px 5px;
+    cursor: pointer;
+    z-index: 5;
+    text-align: center;
+    width: 26px;
+    margin-right: -17px;
+  }
+
   .cal-slide-box {
     border-top: 0px solid #8c8c8c;
   }

--- a/src/less/theme.less
+++ b/src/less/theme.less
@@ -1,12 +1,14 @@
 mwl-calendar {
-  .cal-row-head [class*="cal-cell"] {
-    font-weight: bolder;
-    text-align: center;
-    border: 0px solid;
-    padding: 5px 0;
-  }
-  .cal-row-head [class*="cal-cell"] small {
-    font-weight: normal;
+  .cal-row-head {
+    [class*="cal-cell"] {
+      border: none;
+      padding: 5px 0;
+      text-align: center;
+      font-weight: bolder;
+    }
+    [class*="cal-cell"] small {
+      font-weight: normal;
+    }
   }
   .cal-year-box .row:hover,
   .cal-row-fluid:hover {
@@ -15,6 +17,7 @@ mwl-calendar {
   .cal-month-day {
     height: @rowHeightMonth;
   }
+
   [class*="cal-cell"]:hover,
   .cell-focus,
   [class*="cal-cell"] .drop-active,
@@ -23,20 +26,22 @@ mwl-calendar {
   .cal-day-hour-part.drop-active {
     background-color: @dayHover;
   }
+
   .cal-year-box [class*="span"],
   .cal-month-box [class*="cal-cell"] {
     min-height: @rowHeightMonth;
     position: relative;
   }
 
-  .cal-year-box, .cal-month-box {
+  .cal-year-box,
+  .cal-month-box {
     [class*="span"] + [class*="span"],
     [class*="cal-cell"] + [class*="cal-cell"] {
       border-left: @borderSizevert @borderStyle @borderColor;
     }
   }
 
-  .cal-year-box [class*="span"]{
+  .cal-year-box [class*="span"] {
     min-height: @rowHeightYear;
   }
 
@@ -46,11 +51,7 @@ mwl-calendar {
     margin-left: 0px;
     margin-right: 0px;
   }
-  .cal-year-box .row:last-child,
-  .cal-month-box .cal-row-fluid:last-child {
-    border-bottom: 0px;
-  }
-  .cal-month-box,
+
   .cal-year-box,
   .cal-week-box {
     border-top: @borderSizehoriz @borderStyle @borderColor;
@@ -59,7 +60,7 @@ mwl-calendar {
     border-left: @borderSizevert @borderStyle @borderColor;
     border-radius: 2px;
   }
-  
+
   span[data-cal-date] {
     font-size: 1.2em;
     font-weight: normal;
@@ -99,16 +100,12 @@ mwl-calendar {
     color: darkred;
   }
 
-  #cal-week-box {
+  .cal-week-box-cell {
     border: @borderSize @borderStyle @borderColor;
     border-right: 0px;
     border-radius: 5px 0 0 5px;
     background-color: @rowHover;
     text-align: right;
-  }
-
-  .cal-week-box .cal-row-head {
-    border-bottom: 1px solid #e1e1e1;
   }
 
   .cal-day-tick {
@@ -121,7 +118,6 @@ mwl-calendar {
     .fa {
       display: none;
     }
-
   }
 
   .cal-slide-box {
@@ -167,11 +163,11 @@ mwl-calendar {
     color: #151515;
   }
   .badge-important {
-    background-color:#b94a48;
+    background-color: #b94a48;
   }
 
   .pointer {
-    cursor:pointer;
+    cursor: pointer;
   }
 
   .cal-year-box:last-child {
@@ -197,6 +193,5 @@ mwl-calendar {
     }
 
   }
-
 
 }

--- a/src/less/theme.less
+++ b/src/less/theme.less
@@ -1,6 +1,4 @@
 mwl-calendar {
-
-  .cal-row-head [class*="cal-cell"]:first-child,
   .cal-row-head [class*="cal-cell"] {
     font-weight: bolder;
     text-align: center;
@@ -28,16 +26,20 @@ mwl-calendar {
   .cal-year-box [class*="span"],
   .cal-month-box [class*="cal-cell"] {
     min-height: @rowHeightMonth;
-    border-right: @borderSizevert @borderStyle @borderColor;
     position: relative;
   }
+
+  .cal-year-box, .cal-month-box {
+    [class*="span"] + [class*="span"],
+    [class*="cal-cell"] + [class*="cal-cell"] {
+      border-left: @borderSizevert @borderStyle @borderColor;
+    }
+  }
+
   .cal-year-box [class*="span"]{
     min-height: @rowHeightYear;
   }
-  .cal-year-box .row [class*="col-"]:last-child,
-  .cal-month-box .cal-row [class*="cal-cell"]:last-child {
-    border-right: 0px;
-  }
+
   .cal-year-box .row,
   .cal-month-box .cal-row-fluid {
     border-bottom: @borderSizehoriz @borderStyle @borderColor;
@@ -57,10 +59,7 @@ mwl-calendar {
     border-left: @borderSizevert @borderStyle @borderColor;
     border-radius: 2px;
   }
-  .cal-month-box {
-    border-right: 0px;
-    border-bottom: 0px;
-  }
+  
   span[data-cal-date] {
     font-size: 1.2em;
     font-weight: normal;
@@ -181,6 +180,10 @@ mwl-calendar {
 
   .cal-context {
     width: 100%;
+  }
+
+  .cal-events-num {
+    margin-top: 20px;
   }
 
   @media (max-width: 991px) {

--- a/src/less/week.less
+++ b/src/less/week.less
@@ -17,6 +17,9 @@
     border: 0px !important;
   }
 
+  .cal-row-head {
+    border-bottom: 1px solid #e1e1e1;
+  }
 }
 
 .cal-week-box:not(.cal-day-box) {

--- a/src/services/calendarHelper.js
+++ b/src/services/calendarHelper.js
@@ -94,12 +94,17 @@ angular
       }).length;
     }
 
-    function getWeekDayNames() {
-      var weekdays = [];
-      var count = 0;
-      while (count < 7) {
-        weekdays.push(formatDate(moment().weekday(count++), calendarConfig.dateFormats.weekDay));
-      }
+    function getWeekDayNames(excluded) {
+      var weekdays = [0, 1, 2, 3, 4, 5, 6]
+      .filter(function(wd) {
+        return !(excluded || []).some(function(ex) {
+          return ex === wd;
+        });
+      })
+      .map(function(i) {
+        return formatDate(moment().weekday(i), calendarConfig.dateFormats.weekDay);
+      });
+
       return weekdays;
     }
 
@@ -139,7 +144,7 @@ angular
       return event;
     }
 
-    function getMonthView(events, viewDate, cellModifier) {
+    function getMonthView(events, viewDate, cellModifier, excluded) {
 
       // hack required to work with the calendar-utils api
       events.forEach(function(event) {
@@ -153,6 +158,7 @@ angular
       var view = calendarUtils.getMonthView({
         events: events,
         viewDate: viewDate,
+        excluded: excluded,
         weekStartsOn: moment().startOf('week').day()
       });
 
@@ -177,10 +183,11 @@ angular
 
     }
 
-    function getWeekView(events, viewDate) {
+    function getWeekView(events, viewDate, excluded) {
 
       var days = calendarUtils.getWeekViewHeader({
         viewDate: viewDate,
+        excluded: excluded,
         weekStartsOn: moment().startOf('week').day()
       }).map(function(day) {
         day.date = moment(day.date);
@@ -195,6 +202,7 @@ angular
       var eventRows = calendarUtils.getWeekView({
         viewDate: viewDate,
         weekStartsOn: moment().startOf('week').day(),
+        excluded: excluded,
         events: filterEventsInPeriod(events, startOfWeek, endOfWeek).map(function(event) {
 
           var weekViewStart = moment(startOfWeek).startOf('day');

--- a/src/templates/calendar.html
+++ b/src/templates/calendar.html
@@ -25,6 +25,7 @@
   <mwl-calendar-month
     events="vm.events"
     view-date="vm.viewDate"
+    excluded-days="vm.excludedDays"
     on-event-click="vm.onEventClick"
     on-event-times-changed="vm.onEventTimesChanged"
     on-timespan-click="vm.onTimespanClick"
@@ -42,6 +43,7 @@
   <mwl-calendar-week
     events="vm.events"
     view-date="vm.viewDate"
+    excluded-days="vm.excludedDays"
     on-event-click="vm.onEventClick"
     on-event-times-changed="vm.onEventTimesChanged"
     day-view-start="vm.dayViewStart"

--- a/src/templates/calendarMonthCell.html
+++ b/src/templates/calendarMonthCell.html
@@ -37,7 +37,7 @@
 
   <ng-include src="vm.customTemplateUrls.calendarMonthCellEvents || vm.calendarConfig.templates.calendarMonthCellEvents"></ng-include>
 
-  <div id="cal-week-box" ng-if="$first && rowHovered">
+  <div class="cal-week-box-cell" ng-if="$first && rowHovered">
     <span ng-bind="vm.getWeekNumberLabel(day)"></span>
   </div>
 

--- a/src/templates/calendarMonthView.html
+++ b/src/templates/calendarMonthView.html
@@ -1,17 +1,14 @@
-<div class="cal-row-fluid cal-row-head">
-
-  <div class="cal-cell1" ng-repeat="day in vm.weekDays track by $index" ng-bind="day"></div>
-
-</div>
-<div class="cal-month-box">
-
+<div class="cal-month-box" ng-class="['cal-grid-' + vm.weekDays.length]">
+  <div class="cal-row-fluid cal-row-head">
+    <div class="cal-cell1" ng-repeat="day in vm.weekDays track by $index" ng-bind="day"></div>
+  </div>
   <div
     ng-repeat="rowOffset in vm.monthOffsets track by rowOffset"
     ng-mouseenter="rowHovered = true"
     ng-mouseleave="rowHovered = false">
     <div class="cal-row-fluid cal-before-eventlist">
       <div
-        ng-repeat="day in vm.view | calendarLimitTo:7:rowOffset track by $index"
+        ng-repeat="day in vm.view | calendarLimitTo:vm.weekDays.length:rowOffset track by $index"
         ng-init="dayIndex = vm.view.indexOf(day)"
         class="cal-cell1 cal-cell {{ day.highlightClass }}"
         ng-style="{backgroundColor: day.backgroundColor}"

--- a/src/templates/calendarWeekView.html
+++ b/src/templates/calendarWeekView.html
@@ -1,4 +1,4 @@
-<div class="cal-week-box" ng-class="{'cal-day-box': vm.showTimes}">
+<div class="cal-week-box" ng-class="[{'cal-day-box': vm.showTimes}, 'cal-grid-' + vm.view.days.length]">
   <div class="cal-row-fluid cal-row-head">
 
     <div

--- a/src/templates/calendarWeekView.html
+++ b/src/templates/calendarWeekView.html
@@ -1,6 +1,6 @@
 <div class="cal-week-box" ng-class="[{'cal-day-box': vm.showTimes}, 'cal-grid-' + vm.view.days.length]">
-  <div class="cal-row-fluid cal-row-head">
-
+  <div class="cal-row-fluid cal-row-head"
+       mwl-element-dimensions="vm.dayColumnDimensions">
     <div
       class="cal-cell1"
       ng-repeat="day in vm.view.days track by $index"
@@ -9,7 +9,6 @@
         'cal-day-past': day.isPast,
         'cal-day-today': day.isToday,
         'cal-day-future': day.isFuture}"
-      mwl-element-dimensions="vm.dayColumnDimensions"
       mwl-droppable
       on-drop="vm.eventDropped(dropData.event, day.date)">
 
@@ -34,7 +33,7 @@
       day-view-start="vm.dayViewStart"
       day-view-end="vm.dayViewEnd"
       day-view-split="vm.dayViewSplit"
-      day-width="vm.dayColumnDimensions.width"
+      day-width="vm.dayColumnDimensions.width / vm.view.days.length"
       view-date="vm.viewDate"
       on-timespan-click="vm.onTimespanClick"
       on-date-range-select="vm.onDateRangeSelect"
@@ -54,8 +53,8 @@
             ng-style="{
               top: vm.showTimes ? ((eventRow.top) + 'px') : 'auto',
               position: vm.showTimes ? 'absolute' : 'inherit',
-              width: vm.showTimes ? (vm.dayColumnDimensions.width + 'px') : '',
-              left: vm.showTimes ? (vm.dayColumnDimensions.width * eventRow.offset) + 15 + 'px' : ''
+              width: vm.showTimes ? (vm.dayColumnDimensions.width / vm.view.days.length + 'px') : '',
+              left: vm.showTimes ? ((vm.dayColumnDimensions.width / vm.view.days.length) * eventRow.offset) + 15 + 'px' : ''
             }">
             <div
               class="day-highlight"
@@ -64,13 +63,13 @@
               data-event-class
               mwl-draggable="eventRow.event.draggable === true"
               axis="vm.showTimes ? 'xy' : 'x'"
-              snap-grid="vm.showTimes ? {x: vm.dayColumnDimensions.width, y: vm.dayViewEventChunkSize || 30} : {x: vm.dayColumnDimensions.width}"
+              snap-grid="vm.showTimes ? {x: vm.dayColumnDimensions.width / vm.view.days.length, y: vm.dayViewEventChunkSize || 30} : {x: vm.dayColumnDimensions.width / vm.view.days.length}"
               auto-scroll="vm.draggableAutoScroll"
               on-drag="vm.tempTimeChanged(eventRow.event, y / 30)"
-              on-drag-end="vm.weekDragged(eventRow.event, x / vm.dayColumnDimensions.width, y / 30)"
+              on-drag-end="vm.weekDragged(eventRow.event, x / (vm.dayColumnDimensions.width / vm.view.days.length), y / 30)"
               mwl-resizable="eventRow.event.resizable === true && eventRow.event.endsAt && !vm.showTimes"
               resize-edges="{left: true, right: true}"
-              on-resize-end="vm.weekResized(eventRow.event, edge, x / vm.dayColumnDimensions.width)">
+              on-resize-end="vm.weekResized(eventRow.event, edge, x / (vm.dayColumnDimensions.width / vm.view.days.length))">
               <strong ng-bind="(eventRow.event.tempStartsAt || eventRow.event.startsAt) | calendarDate:'time':true" ng-show="vm.showTimes"></strong>
               <a
                 href="javascript:;"

--- a/src/templates/calendarWeekView.html
+++ b/src/templates/calendarWeekView.html
@@ -33,7 +33,7 @@
       day-view-start="vm.dayViewStart"
       day-view-end="vm.dayViewEnd"
       day-view-split="vm.dayViewSplit"
-      day-width="vm.dayColumnDimensions.width / vm.view.days.length"
+      day-width="(vm.dayColumnDimensions.width - 60) / vm.view.days.length"
       view-date="vm.viewDate"
       on-timespan-click="vm.onTimespanClick"
       on-date-range-select="vm.onDateRangeSelect"
@@ -53,8 +53,8 @@
             ng-style="{
               top: vm.showTimes ? ((eventRow.top) + 'px') : 'auto',
               position: vm.showTimes ? 'absolute' : 'inherit',
-              width: vm.showTimes ? (vm.dayColumnDimensions.width / vm.view.days.length + 'px') : '',
-              left: vm.showTimes ? ((vm.dayColumnDimensions.width / vm.view.days.length) * eventRow.offset) + 15 + 'px' : ''
+              width: vm.showTimes ? ((vm.dayColumnDimensions.width - 60) / vm.view.days.length + 'px') : '',
+              left: vm.showTimes ? (((vm.dayColumnDimensions.width - 60) / vm.view.days.length) * eventRow.offset) + 15 + 'px' : ''
             }">
             <div
               class="day-highlight"
@@ -63,13 +63,13 @@
               data-event-class
               mwl-draggable="eventRow.event.draggable === true"
               axis="vm.showTimes ? 'xy' : 'x'"
-              snap-grid="vm.showTimes ? {x: vm.dayColumnDimensions.width / vm.view.days.length, y: vm.dayViewEventChunkSize || 30} : {x: vm.dayColumnDimensions.width / vm.view.days.length}"
+              snap-grid="vm.showTimes ? {x: (vm.dayColumnDimensions.width - 60) / vm.view.days.length, y: vm.dayViewEventChunkSize || 30} : {x: vm.dayColumnDimensions.width / vm.view.days.length}"
               auto-scroll="vm.draggableAutoScroll"
               on-drag="vm.tempTimeChanged(eventRow.event, y / 30)"
-              on-drag-end="vm.weekDragged(eventRow.event, x / (vm.dayColumnDimensions.width / vm.view.days.length), y / 30)"
+              on-drag-end="vm.weekDragged(eventRow.event, x / ((vm.dayColumnDimensions.width - (vm.showTimes ? 60 : 0)) / vm.view.days.length), y / 30)"
               mwl-resizable="eventRow.event.resizable === true && eventRow.event.endsAt && !vm.showTimes"
               resize-edges="{left: true, right: true}"
-              on-resize-end="vm.weekResized(eventRow.event, edge, x / (vm.dayColumnDimensions.width / vm.view.days.length))">
+              on-resize-end="vm.weekResized(eventRow.event, edge, x / ((vm.dayColumnDimensions.width - (vm.showTimes ? 60 : 0)) / vm.view.days.length))">
               <strong ng-bind="(eventRow.event.tempStartsAt || eventRow.event.startsAt) | calendarDate:'time':true" ng-show="vm.showTimes"></strong>
               <a
                 href="javascript:;"

--- a/test/unit/directives/mwlCalendarMonth.spec.js
+++ b/test/unit/directives/mwlCalendarMonth.spec.js
@@ -132,6 +132,7 @@ describe('mwlCalendarMonth directive', function() {
   it('should toggle the event list for the selected day ', function() {
 
     MwlCalendarCtrl.view = [{date: moment(calendarDay), inMonth: true}];
+    MwlCalendarCtrl.weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
     //Open event list
     MwlCalendarCtrl.cellIsOpen = true;
     scope.$apply();

--- a/test/unit/directives/mwlDateModifier.spec.js
+++ b/test/unit/directives/mwlDateModifier.spec.js
@@ -12,6 +12,7 @@ describe('mwlDateModifier directive', function() {
         'mwl-date-modifier ' +
         'date="date" ' +
         'set-to-today ' +
+        'excluded-days="excludedDays" ' +
         'increment="increment" ' +
         'decrement="decrement" ' +
       '></button>';
@@ -30,7 +31,6 @@ describe('mwlDateModifier directive', function() {
     $rootScope = _$rootScope_;
     scope = $rootScope.$new();
     prepareScope(scope);
-
   }));
 
   it('should increment the date by one unit of the provided attribute value', function() {
@@ -54,6 +54,26 @@ describe('mwlDateModifier directive', function() {
     scope.$apply();
     element.triggerHandler('click');
     expect(scope.date.toString()).to.equal((new Date()).toString());
+  });
+
+  it('should skip the excluded days when incrementing days', function() {
+    element = angular.element(template).removeAttr('set-to-today');
+    scope.date = new Date(2015, 0, 2);
+    scope.excludedDays = [0, 6];
+    element = $compile(element)(scope);
+    scope.$apply();
+    element.triggerHandler('click');
+    expect(scope.date.toString()).to.equal((new Date(2015, 0, 5)).toString());
+  });
+
+  it('should skip the excluded days when decrementing days', function() {
+    element = angular.element(template).removeAttr('set-to-today').removeAttr('increment');
+    scope.excludedDays = [0, 6];
+    scope.decrement = 'days';
+    element = $compile(element)(scope);
+    scope.$apply();
+    element.triggerHandler('click');
+    expect(scope.date.toString()).to.equal((new Date(2015, 0, 2)).toString());
   });
 
 });

--- a/test/unit/services/calendarHelper.spec.js
+++ b/test/unit/services/calendarHelper.spec.js
@@ -179,6 +179,11 @@ describe('calendarHelper', function() {
       moment.locale('en');
     }));
 
+    it('should skip the excluded days', function() {
+      var weekdays = calendarHelper.getWeekDayNames([0,6]);
+      expect(weekdays).to.eql(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']);
+    });
+
   });
 
   describe('getYearView', function() {

--- a/test/unit/services/calendarHelper.spec.js
+++ b/test/unit/services/calendarHelper.spec.js
@@ -180,7 +180,7 @@ describe('calendarHelper', function() {
     }));
 
     it('should skip the excluded days', function() {
-      var weekdays = calendarHelper.getWeekDayNames([0,6]);
+      var weekdays = calendarHelper.getWeekDayNames([0, 6]);
       expect(weekdays).to.eql(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']);
     });
 


### PR DESCRIPTION
Taking inspiration from #570, I modified the directives to add an "excluded-days" attribute, that allows the user to specify which weekdays to include in month and week views.
Date modifier also supports it for day view, optionally skipping some days while navigating.