### PR TITLE
fix(dayView): expose the overlap option in interact

### DIFF
--- a/src/directives/mwlDroppable.js
+++ b/src/directives/mwlDroppable.js
@@ -11,7 +11,7 @@ angular
     }
 
     var DROP_ACTIVE_CLASS = $attrs.dropActiveClass || 'drop-active';
-    var INTERACT_OVERLAP_TYPE = $attrs.mwlDroppable || 'pointer';
+    var INTERACT_OVERLAP_TYPE = $attrs.dropOverlap || 'pointer';
 
     interact($element[0]).dropzone({
       ondragenter: function(event) {

--- a/src/directives/mwlDroppable.js
+++ b/src/directives/mwlDroppable.js
@@ -11,6 +11,7 @@ angular
     }
 
     var DROP_ACTIVE_CLASS = $attrs.dropActiveClass || 'drop-active';
+    var INTERACT_OVERLAP_TYPE = $attrs.mwlDroppable || 'pointer';
 
     interact($element[0]).dropzone({
       ondragenter: function(event) {
@@ -27,7 +28,8 @@ angular
           $parse($attrs.onDrop)($scope, {dropData: event.relatedTarget.dropData});
           $scope.$apply();
         }
-      }
+      },
+      overlap: INTERACT_OVERLAP_TYPE
     });
 
     $scope.$on('$destroy', function() {


### PR DESCRIPTION
Part of an overall change to allow manual resizing of hour-parts (broken out from #620).

Exposes the "overlap" option within interact. I needed to do this because there is a conflict when the dropzone window and the hour part windows are exactly the same size that requires the 'center' value to be used. The 'pointer' value is retained as the default.